### PR TITLE
ルート生成画面の「戻る」ボタンを押した際の処理変更

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,7 +13,9 @@
     console.log("送信された距離:", distance);
     screen = "mapScreen";
   };
+
   const backToHome = () => screen = "home";
+  const backToForm = () => screen = "formScreen";
 </script>
 
 <main>
@@ -39,7 +41,7 @@
   {/if}
 
   {#if screen === "mapScreen"}
-    <MapScreen {animal}{distance}{backToHome}/>
+    <MapScreen {animal}{distance}{backToForm}/>
   {/if}
 
   {#if screen === "collectionScreen"}

--- a/frontend/src/routes/form/MapScreen.svelte
+++ b/frontend/src/routes/form/MapScreen.svelte
@@ -2,7 +2,7 @@
   import RouteMap from "../RouteMap.svelte";
   export let animal: string;
   export let distance: string;
-  export let backToHome: () => void;
+  export let backToForm: () => void;
 
   const handleStart = () => {
     // ルートスタート処理
@@ -16,7 +16,7 @@
 
   <div class="button-group">
     <button class="route-button" on:click={handleStart}>このルートで走る</button>
-    <button class="back-button" on:click={backToHome}>戻る</button>
+    <button class="back-button" on:click={backToForm}>戻る</button>
   </div>
 </div>
 


### PR DESCRIPTION
**ルート生成画面の「戻る」ボタンを押した際の処理変更**

元々ルート生成画面にて，
・「戻る」ボタンを押す→ホーム画面に移行
としていたが，
・「戻る」ボタンを押す→距離・描きたい動物入力フォームに移行
に変更